### PR TITLE
Added Rating And Skills To Person Schema Under Fulfillments

### DIFF
--- a/api/dsep.yaml
+++ b/api/dsep.yaml
@@ -2228,6 +2228,10 @@ components:
           description: 'Gender of something, typically a Person, but possibly also fictional characters, animals, etc. While Male and Female may be used, text strings are also acceptable for people who do not identify as a binary gender'
         cred:
           type: string
+        skills:
+          $ref: '#/components/schemas/Skills'
+        rating:
+          $ref: '#/components/schemas/Rating/properties/value'
         tags:
           $ref: '#/components/schemas/Tags'
     Policy:
@@ -2559,3 +2563,14 @@ components:
           type: string
         registration:
           type: string
+
+    Skills:
+      description: Describes the skills of a person.
+      type: array
+        items:
+          type: object
+          properties:
+            code:
+              type: string
+            name:
+              type: string


### PR DESCRIPTION
With reference to:

- Rating: https://github.com/beckn/DSEP-Specification/discussions/78
We are using the same rating object as the one used for provider.item.

- Skills: https://github.com/beckn/DSEP-Specification/discussions/77