### PR TITLE
Update a broken link to the error codes doc

### DIFF
--- a/api/dsep.yaml
+++ b/api/dsep.yaml
@@ -2005,7 +2005,7 @@ components:
             - JSON-SCHEMA-ERROR
         code:
           type: string
-          description: 'Beckn specific error code. For full list of error codes, refer to docs/protocol-drafts/BECKN-RFC-005-ERROR-CODES-DRAFT-01.md of this repo'
+          description: 'Beckn specific error code. For full list of error codes, refer to docs/BECKN-005-Error-Codes-Draft-01.md of this repo'
         path:
           type: string
           description: Path to json schema generating the error. Used only during json schema validation errors


### PR DESCRIPTION
It would have been nice if the spec could link to the exact file, it took me some time to figure out the actual repo where the file was supposed to be. 😅 

Example: 
Beckn specific error code. For full list of error codes, refer to [BECKN-005-Error-Codes-Draft](https://:ithub.com/beckn/protocol-specifications/blob/master/docs/BECKN-005-Error-Codes-Draft-01.md)
